### PR TITLE
Make memory usage reading support EKS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: erlef/setup-beam@2f0cc07b4b9bea248ae098aba9e1a8a1de5ec24c # v1.17.5
+      - uses: erlef/setup-beam@2@v1.18.2
         with:
           otp-version: ${{ matrix.otp }}
           rebar3-version: ${{ matrix.rebar3 }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: erlef/setup-beam@2@v1.18.2
+      - uses: erlef/setup-beam@v1.18.2
         with:
           otp-version: ${{ matrix.otp }}
           rebar3-version: ${{ matrix.rebar3 }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,6 @@ jobs:
     strategy:
       matrix:
         otp:
-          - 24
           - 25
           - 26
           - 27

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,0 @@
-{"1.2.0",
-[{<<"snabbkaffe">>,{pkg,<<"snabbkaffe">>,<<"1.0.10">>},0}]}.
-[
-{pkg_hash,[
- {<<"snabbkaffe">>, <<"9BE2F54F61FC6862391B666B2B5B76C3FA53598E2989A17CEF1B48CF347A8A63">>}]},
-{pkg_hash_ext,[
- {<<"snabbkaffe">>, <<"70A98DF36AE756908D55B5770891D443D63C903833E3E87D544036E13D4FAC26">>}]}
-].

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,0 +1,8 @@
+{"1.2.0",
+[{<<"snabbkaffe">>,{pkg,<<"snabbkaffe">>,<<"1.0.10">>},0}]}.
+[
+{pkg_hash,[
+ {<<"snabbkaffe">>, <<"9BE2F54F61FC6862391B666B2B5B76C3FA53598E2989A17CEF1B48CF347A8A63">>}]},
+{pkg_hash_ext,[
+ {<<"snabbkaffe">>, <<"70A98DF36AE756908D55B5770891D443D63C903833E3E87D544036E13D4FAC26">>}]}
+].

--- a/src/lc_lib.erl
+++ b/src/lc_lib.erl
@@ -26,7 +26,7 @@
 -export([ get_sys_memory_usage/0
         , get_cgroup_memory_usage/0
         , get_cgroup2_memory_usage/0
-        , get_cgroup3_memory_usage/0
+        , get_cgroup_amzn_memory_usage/0
         ]).
 
 %% @doc Return RAM usage ratio and total number of bytes.
@@ -38,7 +38,7 @@ get_sys_memory() ->
           lists:max([do_get_sys_memory_usage(),
                      do_get_cgroup_memory_usage(),
                      do_get_cgroup2_memory_usage(),
-                     do_get_cgroup3_memory_usage()]);
+                     do_get_cgroup_amzn_memory_usage()]);
       _ ->
           do_get_sys_memory_usage()
   end.
@@ -133,12 +133,12 @@ do_get_cgroup2_memory_usage() ->
     {0, 0}
   end.
 
--spec get_cgroup3_memory_usage() -> number().
-get_cgroup3_memory_usage() ->
-  {Ratio, _Total} = do_get_cgroup3_memory_usage(),
+-spec get_cgroup_amzn_memory_usage() -> number().
+get_cgroup_amzn_memory_usage() ->
+  {Ratio, _Total} = do_get_cgroup_amzn_memory_usage(),
   Ratio.
 
-do_get_cgroup3_memory_usage() ->
+do_get_cgroup_amzn_memory_usage() ->
   try
     CgroupUsed = read_int_fs(filename:join(["/sys/fs/cgroup/memory",
       "memory.usage_in_bytes"])

--- a/src/lc_lib.erl
+++ b/src/lc_lib.erl
@@ -26,6 +26,7 @@
 -export([ get_sys_memory_usage/0
         , get_cgroup_memory_usage/0
         , get_cgroup2_memory_usage/0
+        , get_cgroup3_memory_usage/0
         ]).
 
 %% @doc Return RAM usage ratio and total number of bytes.
@@ -36,7 +37,8 @@ get_sys_memory() ->
     {unix, linux} ->
           lists:max([do_get_sys_memory_usage(),
                      do_get_cgroup_memory_usage(),
-                     do_get_cgroup2_memory_usage()]);
+                     do_get_cgroup2_memory_usage(),
+                     do_get_cgroup3_memory_usage()]);
       _ ->
           do_get_sys_memory_usage()
   end.
@@ -126,6 +128,23 @@ do_get_cgroup2_memory_usage() ->
                             ),
     CgroupTotal = read_int_fs(filename:join(["/sys/fs/cgroup/",
                                              "memory.max"])),
+    {CgroupUsed/CgroupTotal, CgroupTotal}
+  catch error:_ ->
+    {0, 0}
+  end.
+
+-spec get_cgroup3_memory_usage() -> number().
+get_cgroup3_memory_usage() ->
+  {Ratio, _Total} = do_get_cgroup3_memory_usage(),
+  Ratio.
+
+do_get_cgroup3_memory_usage() ->
+  try
+    CgroupUsed = read_int_fs(filename:join(["/sys/fs/cgroup/memory",
+      "memory.usage_in_bytes"])
+    ),
+    CgroupTotal = read_int_fs(filename:join(["/sys/fs/cgroup/memory",
+      "memory.limit_in_bytes"])),
     {CgroupUsed/CgroupTotal, CgroupTotal}
   catch error:_ ->
     {0, 0}

--- a/src/lc_lib.erl
+++ b/src/lc_lib.erl
@@ -129,10 +129,14 @@ get_cgroup2_memory_usage() ->
 
 do_get_cgroup2_memory_usage() ->
   try
-    CgroupUsed = read_int_fs(filename:join(["/sys/fs/cgroup/",
+    Cgroup = "/sys/fs/cgroup",
+    Paths = [filename:join(Cgroup, get_cgroup_path(<<>>)),
+             Cgroup],
+    CgroupPath = first_existing(Paths),
+    CgroupUsed = read_int_fs(filename:join([CgroupPath,
                                             "memory.current"])
                             ),
-    CgroupTotal = read_int_fs(filename:join(["/sys/fs/cgroup/",
+    CgroupTotal = read_int_fs(filename:join([CgroupPath,
                                              "memory.max"])),
     {CgroupUsed/CgroupTotal, CgroupTotal}
   catch error:_ ->


### PR DESCRIPTION
fix: #20 
Using the 0.3.3 version of the library, the following two methods for figuring out memory limit and usage from the OS seems to fail to return any values in my EKS cluster:

1. `lc_lib:do_get_cgroup_memory_usage/0` parses the cgroup memory path correctly (https://github.com/emqx/lc/issues/17 works!) and constructs the filename correctly, but the resulted file (`/sys/fs/cgroup/memory/kubepods.slice/kubepods-pod30d0fb1f_937d_45c1_b986_fd363a73f1ea.slice/cri-containerd-3bf62db008468812fcafe483b22a094339421d780dccee198a27d105e828c2f4.scope/memory.usage_in_bytes`) does not exist
2. `lc_lib:get_cgroup2_memory_usage/0` also fails because `/sys/fs/cgroup/memory.current` does not exist either

I would suggest to include a 3rd method that I found working:
```
do_get_cgroup3_memory_usage() ->
    try
        CgroupUsed = read_int_fs(filename:join(["/sys/fs/cgroup/memory",
            "memory.usage_in_bytes"])
        ),
        CgroupTotal = read_int_fs(filename:join(["/sys/fs/cgroup/memory",
            "memory.limit_in_bytes"])),
        {CgroupUsed/CgroupTotal, CgroupTotal}
    catch error:_ ->
        {0, 0}
    end.
```
The above method parse these values:
```
$ cat /sys/fs/cgroup/memory/memory.usage_in_bytes
761204736
$ cat /sys/fs/cgroup/memory/memory.limit_in_bytes 
3145728000
```
```
> lc_lib:get_cgroup_memory_usage(). 
0
> lc_lib:get_cgroup2_memory_usage().
0
> lc_lib:get_cgroup3_memory_usage().
0.24186197916666666
```

